### PR TITLE
Fix OpenMeteo processor dropping grid locations with NaN city values

### DIFF
--- a/scripts/processors/openmeteo_processor.py
+++ b/scripts/processors/openmeteo_processor.py
@@ -73,7 +73,7 @@ class OpenMeteoProcessor(BaseProcessor):
         )
         
         pivot_df = df.pivot_table(
-            index=['timestamp', 'location_id', 'location_name', 'latitude', 'longitude', 'city', 'country'],
+            index=['timestamp', 'location_id', 'location_name', 'latitude', 'longitude', 'country'],
             columns='parameter',
             values='value',
             aggfunc='mean'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated data aggregation across cities; results are now grouped by timestamp and location rather than city.
  * The city field is no longer present in outputs; city-level granularity has been removed.
  * Metrics may appear combined for locations that previously differed only by city.
  * Hexagon/hour aggregation, data source tagging, and country attribution remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->